### PR TITLE
added setFieldError to actions object to allow custom actions to set …

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,10 @@ A function you can call to update a field's value in the form.
 
 A function you can call to trigger an `onActionCallback` on the FormBuilder component.
 
+### setFieldError: (fieldPath, errorMessage: string[]) => void
+
+A function you call to set a field error on the field.
+
 
 ## Want to contribute?
 

--- a/src/FormBuilder.js
+++ b/src/FormBuilder.js
@@ -222,6 +222,7 @@ export default class FormBuilder extends React.Component {
 				submitForm: () => {
 					this.formikRef.submitForm();
 				},
+				setFieldError: this.formikRef.setFieldError,
 			});
 		}
 	}


### PR DESCRIPTION
This PR will expose the setError method in the custom form actions.

The reason for this, is for the user to be able to set field level error messages.

This can be responses from the server on a submit, from custom actions etc.